### PR TITLE
escape file path to bt2index.

### DIFF
--- a/R/bowtie2.R
+++ b/R/bowtie2.R
@@ -251,7 +251,7 @@ bowtie2_samtools <- function(bt2Index,output,outputType = "sam", seq1=NULL, seq2
     }
 
     # Create the explicit arguments for the binaries
-    argvs = c("-x",bt2Index)
+    argvs = c("-x",shQuote(bt2Index))
 
     if(!is.null(seq1) && is.null(seq2)){
         if(interleaved){


### PR DESCRIPTION
bowtie2 command does not start when the path to the bt2index containing spaces, use shQuote to escape the space.