### PR TITLE
Add 'simde' as a Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "simde"]
+	path = src/bowtie2-2.4.4/third_party/simde
+	url = https://github.com/simd-everywhere/simde-no-tests.git
+	branch = master


### PR DESCRIPTION
Fixes #7

Used the following command to add the submodule:

`git submodule add  --name simde -b master https://github.com/simd-everywhere/simde-no-tests.git src/bowtie2-2.4.4/third_party/simde`